### PR TITLE
feat: add `DRONE_BUILD_PARENT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following variables could be configured on a nomad template with the followi
 | DRONE_COMMIT_MESSAGE | | commit message |
 | DRONE_BUILD_EVENT | | build event |
 | DRONE_BUILD_NUMBER | | build number |
+| DRONE_BUILD_PARENT | | build parent |
 | DRONE_BUILD_STATUS | | build status |
 | DRONE_BUILD_LINK | | build link |
 | DRONE_BUILD_STARTED | | build started |

--- a/main.go
+++ b/main.go
@@ -148,6 +148,11 @@ func main() {
 			Usage:  "build number",
 			EnvVar: "DRONE_BUILD_NUMBER",
 		},
+		cli.IntFlag{
+			Name:   "build.parent",
+			Usage:  "build parent",
+			EnvVar: "DRONE_BUILD_PARENT",
+		},
 		cli.StringFlag{
 			Name:   "build.status",
 			Usage:  "build status",
@@ -195,6 +200,7 @@ func run(c *cli.Context) error {
 		Build: Build{
 			Tag:     c.String("build.tag"),
 			Number:  c.Int("build.number"),
+			Parent:  c.Int("build.parent"),
 			Event:   c.String("build.event"),
 			Status:  c.String("build.status"),
 			Commit:  c.String("commit.sha"),

--- a/plugin.go
+++ b/plugin.go
@@ -30,6 +30,7 @@ type (
 		Tag     string `json:"tag" env:"DRONE_TAG"`
 		Event   string `json:"event" env:"DRONE_BUILD_EVENT"`
 		Number  int    `json:"number" env:"DRONE_BUILD_NUMBER"`
+		Parent  int    `json:"parent" env:"DRONE_BUILD_PARENT"`
 		Commit  string `json:"commit" env:"DRONE_COMMIT_SHA"`
 		Ref     string `json:"ref" env:"DRONE_COMMIT_REF"`
 		Branch  string `json:"branch" env:"DRONE_COMMIT_BRANCH"`


### PR DESCRIPTION
This PR adds support for DRONE_BUILD_PARENT, which provides the parent build number for the current running build. The parent build number is populated from an exiting build that is being promoted.