### PR TITLE
feat: allow consul ACL token to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following variables could be configured on a nomad template with the followi
 | Environment | Argument | Description |
 |---|---|---|
 | PLUGIN_ADDR | | nomad addr |
+| PLUGIN_CONSUL_TOKEN | | consul token |
 | PLUGIN_TOKEN | | nomad token |
 | PLUGIN_REGION | | nomad region |
 | PLUGIN_NAMESPACE | | nomad namespace |

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ func main() {
 			EnvVar: "PLUGIN_TOKEN",
 		},
 		cli.StringFlag{
+			Name:   "consul_token",
+			Usage:  "consul token",
+			EnvVar: "PLUGIN_CONSUL_TOKEN",
+		},
+		cli.StringFlag{
 			Name:   "region",
 			Usage:  "nomad region",
 			EnvVar: "PLUGIN_REGION",
@@ -232,6 +237,7 @@ func run(c *cli.Context) error {
 		Config: Config{
 			Address:                c.String("addr"),
 			Token:                  c.String("token"),
+			ConsulToken:            c.String("consul_token"),
 			Region:                 c.String("region"),
 			Namespace:              c.String("namespace"),
 			Template:               c.String("template"),

--- a/plugin.go
+++ b/plugin.go
@@ -52,6 +52,7 @@ type (
 	Config struct {
 		Address                string        `json:"address" env:"PLUGIN_ADDR"`
 		Token                  string        `json:"token" env:"PLUGIN_TOKEN"`
+		ConsulToken            string        `json:"consul_token" env:"PLUGIN_CONSUL_TOKEN"`
 		Region                 string        `json:"region" env:"PLUGIN_REGION"`
 		Namespace              string        `json:"namespace" env:"PLUGIN_NAMESPACE"`
 		Template               string        `json:"template" env:"PLUGIN_TEMPLATE"`
@@ -121,6 +122,11 @@ func (p Plugin) Exec() error {
 	nomadTemplate, err := nomad.ParseTemplate(nomadTemplateSubst)
 	if err != nil {
 		return err
+	}
+
+	// Set consul ACL token
+	if p.Config.ConsulToken != "" {
+		*nomadTemplate.ConsulToken = p.Config.ConsulToken
 	}
 
 	// Log template to STDOUT when debugging is enabled


### PR DESCRIPTION
For those who operate nomad with an ACL-enabled consul setup, it's essential to be able to provide a consul token.